### PR TITLE
Add target=blank to open in a new tab

### DIFF
--- a/baseline-status.js
+++ b/baseline-status.js
@@ -345,7 +345,7 @@ export class BaselineStatus extends LitElement {
         ${description}
       </p>
       <p>
-        ${baseline === 'no_data' ? '' : html`<a href="https://github.com/web-platform-dx/web-features/blob/main/features/${feature.feature_id}.yml" target="_blank">Learn more</a>`}
+        ${baseline === 'no_data' ? '' : html`<a href="https://github.com/web-platform-dx/web-features/blob/main/features/${feature.feature_id}.yml" target="_top">Learn more</a>`}
       </p>
     </details>`;
   }

--- a/baseline-status.js
+++ b/baseline-status.js
@@ -345,7 +345,7 @@ export class BaselineStatus extends LitElement {
         ${description}
       </p>
       <p>
-        ${baseline === 'no_data' ? '' : html`<a href="https://github.com/web-platform-dx/web-features/blob/main/features/${feature.feature_id}.yml">Learn more</a>`}
+        ${baseline === 'no_data' ? '' : html`<a href="https://github.com/web-platform-dx/web-features/blob/main/features/${feature.feature_id}.yml" target="_blank">Learn more</a>`}
       </p>
     </details>`;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baseline-status",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A widget displaying Baseline status of a web feature",
   "main": "baseline-status.js",
   "type": "module",


### PR DESCRIPTION
The widget is quite often used in an iframe. It feels awkward to open a "Learn more" link that leads to the documentation inside of an iframe. It also allows to avoid CSP errors caused by the directive: "frame-ancestors 'none'".