### PR TITLE
fix #10

### DIFF
--- a/baseline-status.js
+++ b/baseline-status.js
@@ -54,13 +54,13 @@ export class BaselineStatus extends LitElement {
   static get styles() {
     return css`
       :host {
-        --color-limited: #ea8600;
-        --color-newly: #1a73e8;
-        --color-widely: #1e8e3e;
-        --color-no_data: #707070;
-        --color-outline: #d9d9d9;
-        --color-text: #000;
-        --color-link: #1a73e8;
+        --color-limited: light-dark(#ea8600, #f09418);
+        --color-newly: light-dark(#1a73e8, #4185ff);
+        --color-widely: light-dark(#1e8e3e, #24a446);
+        --color-no_data: light-dark(#707070, #868686);
+        --color-outline: light-dark(#d9d9d9, #d9d9d9);
+        --color-text: light-dark(#000, #fff);
+        --color-link: light-dark(#1a73e8, #5aa1ff);
 
         color: var(--color-text);
         display: block;
@@ -71,20 +71,6 @@ export class BaselineStatus extends LitElement {
         font-family: Roboto, sans-serif;
         font-size: 14px;
         font-style: normal;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        :host {
-          --color-limited: #f09418;
-          --color-newly: #4185ff;
-          --color-widely: #24a446;
-          --color-no_data: #868686;
-
-          --color-outline: #d9d9d9;
-          --color-text: #fff;
-          --color-background: #121212;
-          --color-link: #5aa1ff;
-        }
       }
 
       h1 {

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,14 +10,10 @@
     <style>
       body {
         font-family: Roboto, sans-serif;
+        background-color: light-dark(#fff, #222);
       }
       baseline-status {
         margin-block-end: 1rem;
-      }
-      @media (prefers-color-scheme: dark) {
-        body {
-          background-color: #222;
-        }
       }
     </style>
   </head>


### PR DESCRIPTION
instead of only using `prefers-color-scheme`, switching to the `light-dark()` function ensures the users preference AND the value of `color-scheme` are respected. 

<details>
<summary>Broken: preference is dark but color-scheme is light</summary>

![Screenshot 2024-09-19 at 9 10 50 AM](https://github.com/user-attachments/assets/ec183d30-550e-456a-b548-d200df68ffac)

</details>

<details>
<summary>Fix</summary>

![Screenshot 2024-09-19 at 9 14 21 AM](https://github.com/user-attachments/assets/dafae5f3-568c-4c85-b4f1-6713c2ccf26f)


</details>