### PR TITLE
Point to the last released version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ the packages
 It can be used for quick testing and prototyping.
 
 ```
-<script src="https://cdn.jsdelivr.net/npm/baseline-status@1.0.4/baseline-status.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/baseline-status@1.0.7/baseline-status.min.js" type="module"></script>
 <baseline-status featureId="anchor-positioning"></baseline-status>
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ the packages
 It can be used for quick testing and prototyping.
 
 ```
-<script src="https://cdn.jsdelivr.net/npm/baseline-status@1.0.7/baseline-status.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/baseline-status@1.0.8/baseline-status.min.js" type="module"></script>
 <baseline-status featureId="anchor-positioning"></baseline-status>
 ```
 


### PR DESCRIPTION
People tend to copy-paste a lot 😀

And even if the CDN version is not a preferable one, there’s still a use case for it. For example, in your slides.