### PR TITLE
more finite transition style

### DIFF
--- a/baseline-status.js
+++ b/baseline-status.js
@@ -162,7 +162,7 @@ export class BaselineStatus extends LitElement {
       }
 
       details > summary .open-icon svg {
-        transition: all 0.3s;
+        transition: transform 0.3s;
       }
 
       details[open] summary .open-icon svg {


### PR DESCRIPTION
Noticed that the open-icon was triggering `scrollbar-color` transitions over and over in a page I'm building and noticed `transition: all 0.3s`. Strange behavior, also stealing GPU.

Easily pacified tho by specifying only transition transform, which afaict, that's all this was meant to transition anyway, the twirl open effect.

Here's a picture of the problem. You can see scrollbar-color included in the transforms, which isnt performant, and is unnecessary. 

<img width="998" alt="Screenshot 2024-11-07 at 10 52 57 AM" src="https://github.com/user-attachments/assets/4b68f431-c383-4d29-8c59-805b67305f42">
