### PR TITLE
Re-fetch data on featureId change

### DIFF
--- a/baseline-status.js
+++ b/baseline-status.js
@@ -350,8 +350,6 @@ export class BaselineStatus extends LitElement {
       error: () => this.renderTemplate(missingFeature),
     });
   }
-
-  up
 }
 
 window.customElements.define('baseline-status', BaselineStatus);

--- a/baseline-status.js
+++ b/baseline-status.js
@@ -198,16 +198,15 @@ export class BaselineStatus extends LitElement {
   }
 
   fetchData = new Task(this, {
-    // eslint-disable-next-line no-unused-vars
     task: async ([featureId], { signal }) => {
-      const url = API_ENDPOINT + this.featureId;
+      const url = API_ENDPOINT + featureId;
       const response = await fetch(url, { signal, cache: 'force-cache' });
       if (!response.ok) {
         throw new Error(response.status);
       }
       return response.json();
     },
-    args: () => ['_'],
+    args: () => [this.featureId],
   });
 
   renderSupportIcon(baseline, browserImplementation) {
@@ -351,6 +350,8 @@ export class BaselineStatus extends LitElement {
       error: () => this.renderTemplate(missingFeature),
     });
   }
+
+  up
 }
 
 window.customElements.define('baseline-status', BaselineStatus);

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 
 <html>
   <head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 
 <html>
   <head>
@@ -25,5 +25,15 @@
     <baseline-status featureId="abs-sign"></baseline-status>
     <baseline-status featureid="i-dont-exist"></baseline-status>
     <baseline-status></baseline-status>
+    <label for="dynamic-feature-input">Feature id</label>
+    <input type="text" id="dynamic-feature-input" />
+    <baseline-status id="dynamic-feature-output"></baseline-status>
+    <script>
+      const input = document.getElementById("dynamic-feature-input");
+      const output = document.getElementById("dynamic-feature-output");
+      input.addEventListener("change", (event) => {
+        output.setAttribute("featureId", event.target.value);
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Previously, the `featureId` change was not triggering a data refresh. This makes the component reactive to the featureId changing, and adds an example to the demo page.

It appears this behavior was intentionally disabled in the initial commit, so I'm curious if this is potentially working as intended.