### PR TITLE
Add heading level property

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ Show Baseline status widget for
 <baseline-status featureId="anchor-positioning"></baseline-status>
 ```
 
+By default, the heading level is `<h2>`. You can change this with the `heading`
+attribute:
+
+```
+<baseline-status featureId="calc-size" heading="3"></baseline-status>
+```
+Heading levels from `"1"` to `"6"` and `"h1"` to `"h6"` are supported. This only
+changes the semantic level, and not the styling.
+
 ## Usage
 
 *Option 1. Install and bundle with your application*

--- a/baseline-status.js
+++ b/baseline-status.js
@@ -307,34 +307,35 @@ export class BaselineStatus extends LitElement {
     switch (this.heading.toLowerCase()) {
       case '1':
       case 'h1':
-        heading = `<h1>${feature.name}</h1>`
+        heading = html`<h1>${feature.name}</h1>`
         break;
       case '2':
       case 'h2':
-        heading = `<h2>${feature.name}</h2>`
+        heading = html`<h2>${feature.name}</h2>`
         break;
       case '3':
       case 'h3':
-        heading = `<h3>${feature.name}</h3>`
+        heading = html`<h3>${feature.name}</h3>`
         break;
       case '4':
       case 'h4':
-        heading = `<h4>${feature.name}</h4>`
+        heading = html`<h4>${feature.name}</h4>`
         break;
       case '5':
       case 'h5':
-        heading = `<h5>${feature.name}</h5>`
+        heading = html`<h5>${feature.name}</h5>`
         break;
       case '6':
       case 'h6':
-        heading = `<h6>${feature.name}</h6>`
+        heading = html`<h6>${feature.name}</h6>`
         break;
       default:
-        heading = `<h2>${feature.name}</h2>`
+        heading = html`<h2>${feature.name}</h2>`
         break;
     }
 
-    return html` ${unsafeHTML(heading)}
+    return html` 
+      ${heading}
       <details>
         <summary
           aria-label="${getAriaLabel(

--- a/baseline-status.js
+++ b/baseline-status.js
@@ -1,6 +1,5 @@
 import { LitElement, html, css } from 'lit';
 import { Task } from '@lit/task';
-import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 
 // eslint-disable-next-line no-unused-vars
 import BaselineIcon from './baseline-icon.js';

--- a/baseline-status.js
+++ b/baseline-status.js
@@ -1,5 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { Task } from '@lit/task';
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+
 // eslint-disable-next-line no-unused-vars
 import BaselineIcon from './baseline-icon.js';
 
@@ -72,7 +74,7 @@ export class BaselineStatus extends LitElement {
         font-style: normal;
       }
 
-      h1 {
+      h1,h2,h3,h4,h5,h6 {
         font-weight: normal;
         font-size: 20px;
         margin: 0;
@@ -194,7 +196,18 @@ export class BaselineStatus extends LitElement {
        * @type {string}
        */
       featureId: { type: String },
+      /**
+       * Heading level to use for the feature title.
+       * @type {string}
+       * @default "2"
+       */
+      heading: { type: String },
     };
+  }
+
+  constructor() {
+    super();
+    this.heading = '2';
   }
 
   fetchData = new Task(this, {
@@ -290,7 +303,38 @@ export class BaselineStatus extends LitElement {
       return `Baseline: ${title}${year ? ` ${year}` : ''}${badge ? ` (newly available)` : ''}. Supported in Chrome: ${chrome === 'available' ? 'yes' : chrome}. Supported in Edge: ${edge === 'available' ? 'yes' : edge}. Supported in Firefox: ${firefox === 'available' ? 'yes' : firefox}. Supported in Safari: ${safari === 'available' ? 'yes' : safari}.`;
     };
 
-    return html` <h1>${feature.name}</h1>
+    let heading;
+    switch (this.heading.toLowerCase()) {
+      case '1':
+      case 'h1':
+        heading = `<h1>${feature.name}</h1>`
+        break;
+      case '2':
+      case 'h2':
+        heading = `<h2>${feature.name}</h2>`
+        break;
+      case '3':
+      case 'h3':
+        heading = `<h3>${feature.name}</h3>`
+        break;
+      case '4':
+      case 'h4':
+        heading = `<h4>${feature.name}</h4>`
+        break;
+      case '5':
+      case 'h5':
+        heading = `<h5>${feature.name}</h5>`
+        break;
+      case '6':
+      case 'h6':
+        heading = `<h6>${feature.name}</h6>`
+        break;
+      default:
+        heading = `<h2>${feature.name}</h2>`
+        break;
+    }
+
+    return html` ${unsafeHTML(heading)}
       <details>
         <summary
           aria-label="${getAriaLabel(

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,9 +20,9 @@
   <body>
     <h1>&lt;baseline-status&gt; demo</h1>
     <baseline-status featureId="array"></baseline-status>
-    <baseline-status featureId="anchor-positioning"></baseline-status>
-    <baseline-status featureId="animation-composition"></baseline-status>
-    <baseline-status featureId="abs-sign"></baseline-status>
+    <baseline-status featureId="anchor-positioning" heading="1"></baseline-status>
+    <baseline-status featureId="animation-composition" heading="h3"></baseline-status>
+    <baseline-status featureId="</h2>"></baseline-status>
     <baseline-status featureid="i-dont-exist"></baseline-status>
     <baseline-status></baseline-status>
   </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,7 @@
     <baseline-status featureId="array"></baseline-status>
     <baseline-status featureId="anchor-positioning" heading="1"></baseline-status>
     <baseline-status featureId="animation-composition" heading="h3"></baseline-status>
-    <baseline-status featureId="</h2>"></baseline-status>
+    <baseline-status featureId="abs-sign"></baseline-status>
     <baseline-status featureid="i-dont-exist"></baseline-status>
     <baseline-status></baseline-status>
   </body>


### PR DESCRIPTION
Fixes #28 

This PR changes the default heading level to `h2` and adds a new `heading` property that takes `1`-`6` and `h1`-`h6`.

All the heading levels are styled identically, and the change is solely semantic.
