### PR TITLE
Add Copyright statement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,21 @@ To run locally:
 The local server uses wds [@web/dev-server](https://modern-web.dev/docs/dev-server/overview/) package.
 To enable web component related polyfills for legacy browsers, it uses `@web/dev-server-legacy` package.
 See `web-dev-server.config` file for the exact configuration.
+
+## Copyright and license
+
+Code is released under the [Apache License, Version 2.0](LICENSE) with the following notice:
+
+> Copyright [baseline-status contributors](https://github.com/web-platform-dx/baseline-status/graphs/contributors)
+>
+> Licensed under the Apache License, Version 2.0 (the "License");
+> you may not use this file except in compliance with the License.
+> You may obtain a copy of the License at
+>
+>   http://www.apache.org/licenses/LICENSE-2.0
+>
+> Unless required by applicable law or agreed to in writing, software
+> distributed under the License is distributed on an "AS IS" BASIS,
+> WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+> See the License for the specific language governing permissions and
+> limitations under the License.


### PR DESCRIPTION
Via #55. To apply the Apache License, the boilerplate notice should be specified, and the copyright owner clarified.

The Community License Agreement that WebDX CG participants signed when they joined the group covers Specifications and does not have anything to say about projects such as this one. Making the copyright owner "baseline-status contributors" as a result.

The notice could be added to each and every source file. This update keeps things simple and adds it once to the README file instead.

The copyright year is not specified but I don't think that matters much these days, and this avoids having to get back to it to update the years over time.