### PR TITLE
Improve CSS encapsulation

### DIFF
--- a/baseline-status.js
+++ b/baseline-status.js
@@ -106,6 +106,7 @@ export class BaselineStatus extends LitElement {
         display: flex;
         align-items: center;
         gap: 0.2rem;
+        line-height: normal;
       }
 
       .baseline-badge {
@@ -151,6 +152,7 @@ export class BaselineStatus extends LitElement {
       details > summary .open-icon {
         width: 10px;
         height: 20px;
+        line-height: normal;
         margin-left: auto;
         color: inherit;
       }
@@ -303,14 +305,14 @@ export class BaselineStatus extends LitElement {
       <details>
         <summary
           aria-label="${getAriaLabel(
-            title,
-            year,
-            badge,
-            chrome?.status,
-            edge?.status,
-            firefox?.status,
-            safari?.status,
-          )}"
+      title,
+      year,
+      badge,
+      chrome?.status,
+      edge?.status,
+      firefox?.status,
+      safari?.status,
+    )}"
         >
           <baseline-icon support="${baseline}" aria-hidden="true"></baseline-icon>
           <div class="baseline-status-title" aria-hidden="true">


### PR DESCRIPTION
Hi, thanks for your work

I suggest to add encapsulation for the `line-height` property from the host.

Changing of  `line-height` on host also impacts on `<baseline-status>` elements.
for instance:

<img width="392" height="182" alt="изображение" src="https://github.com/user-attachments/assets/c8775cee-e822-4347-8927-7b0572516e00" />

Results:
| current | PR |
|--------|--------|
| <img width="856" height="132" alt="изображение" src="https://github.com/user-attachments/assets/d7a21949-ce2b-431d-8f6f-45f849c9e25c" /> | <img width="858" height="118" alt="изображение" src="https://github.com/user-attachments/assets/24a05f67-ff01-438a-a6a5-befc11b990ca" />| 