### PR TITLE
Provide some feedback for feature moves and splits

### DIFF
--- a/baseline-status.js
+++ b/baseline-status.js
@@ -212,7 +212,14 @@ export class BaselineStatus extends LitElement {
       const url = API_ENDPOINT + featureId;
       const response = await fetch(url, { signal, cache: 'force-cache' });
       if (!response.ok) {
+        if (response.status === 410) {
+          console.warn(`baseline-status: ${featureId} data has been removed or split. Update your featureId.`);
+        }
         throw new Error(response.status);
+      }
+      if (response.redirected) {
+        const newId = new URL(response.url).pathname.split("/").at(-1);
+        console.warn(`baseline-status: ${featureId} is now ${newId}. Update your featureId.`);
       }
       return response.json();
     },


### PR DESCRIPTION
This is a very simple—maybe even bad—attempt to provide some feedback to baseline-status users affected by the v3 changes coming to web-features.

There's probably a nicer way to show this information, but I wasn't sure how to do it, so I thought I would open the PR to show how it might be known that a feature was moved or split.