### PR TITLE
Consider mobile support in browser availability

### DIFF
--- a/baseline-status.js
+++ b/baseline-status.js
@@ -219,9 +219,14 @@ export class BaselineStatus extends LitElement {
     args: () => [this.featureId],
   });
 
-  renderSupportIcon(baseline, browserImplementation) {
+  checkAvailability(implementations) {
+    return implementations.every((impl) => impl?.status === 'available');
+  }
+
+  renderSupportIcon(baseline, implementations) {
+    const allAvailable = this.checkAvailability(implementations);
     const support = (baseline === 'limited')
-      ? (browserImplementation?.status || 'unavailable')
+      ? (allAvailable ? 'available' : 'unavailable')
       : baseline;
     const icon = (support === 'newly' || support === 'widely')
       ? 'available'
@@ -281,7 +286,7 @@ export class BaselineStatus extends LitElement {
       baselineDate.split(' ')[1] :
       '';
 
-    const { chrome, edge, firefox, safari } =
+    const { chrome, chrome_android, edge, firefox, firefox_android, safari, safari_ios } =
       feature.browser_implementations || {};
 
     const getAriaLabel = (
@@ -299,6 +304,8 @@ export class BaselineStatus extends LitElement {
       return `Baseline: ${title}${year ? ` ${year}` : ''}${badge ? ` (newly available)` : ''}. Supported in Chrome: ${chrome === 'available' ? 'yes' : chrome}. Supported in Edge: ${edge === 'available' ? 'yes' : edge}. Supported in Firefox: ${firefox === 'available' ? 'yes' : firefox}. Supported in Safari: ${safari === 'available' ? 'yes' : safari}.`;
     };
 
+    const getStatus = (impls) => this.checkAvailability(impls) ? 'available' : 'no';
+
     return html` <div class="name">${feature.name}</div>
       <details>
         <summary
@@ -306,20 +313,20 @@ export class BaselineStatus extends LitElement {
             title,
             year,
             badge,
-            chrome?.status,
-            edge?.status,
-            firefox?.status,
-            safari?.status,
+            getStatus([chrome, chrome_android]),
+            getStatus([edge]),
+            getStatus([firefox, firefox_android]),
+            getStatus([safari, safari_ios]),
           )}"
         >
           <baseline-icon support="${baseline}" aria-hidden="true"></baseline-icon>
           <div class="baseline-status-title" aria-hidden="true">
             <div>${preTitle} ${title} ${year} ${badge}</div>
             <div class="baseline-status-browsers">
-              <span>${ICONS['chrome']} ${this.renderSupportIcon(baseline, chrome)}</span>
-              <span>${ICONS['edge']} ${this.renderSupportIcon(baseline, edge)}</span>
-              <span>${ICONS['firefox']} ${this.renderSupportIcon(baseline, firefox)}</span>
-              <span>${ICONS['safari']} ${this.renderSupportIcon(baseline, safari)}</span>
+              <span>${ICONS['chrome']} ${this.renderSupportIcon(baseline, [chrome, chrome_android])}</span>
+              <span>${ICONS['edge']} ${this.renderSupportIcon(baseline, [edge])}</span>
+              <span>${ICONS['firefox']} ${this.renderSupportIcon(baseline, [firefox, firefox_android])}</span>
+              <span>${ICONS['safari']} ${this.renderSupportIcon(baseline, [safari, safari_ios])}</span>
             </div>
           </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baseline-status",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baseline-status",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@lit/task": "^1.0.0",

--- a/test/__snapshots__/baseline-status.test.snap.js
+++ b/test/__snapshots__/baseline-status.test.snap.js
@@ -389,3 +389,61 @@ snapshots["Baseline-status renders baseline widget for a feature from feature-id
 `;
 /* end snapshot Baseline-status renders baseline widget for a feature from feature-id attribute */
 
+snapshots["Baseline-status renders limited availability correctly when mobile support is missing"] = 
+`<div class="name">
+  paint-order
+</div>
+<details>
+  <summary aria-label="Baseline: Limited availability. Supported in Chrome: yes. Supported in Edge: yes. Supported in Firefox: yes. Supported in Safari: no.">
+    <baseline-icon
+      aria-hidden="true"
+      support="limited"
+    >
+    </baseline-icon>
+    <div
+      aria-hidden="true"
+      class="baseline-status-title"
+    >
+      <div>
+        Limited availability
+      </div>
+      <div class="baseline-status-browsers">
+        <span>
+          <browser-support-icon class="support-available">
+          </browser-support-icon>
+        </span>
+        <span>
+          <browser-support-icon class="support-available">
+          </browser-support-icon>
+        </span>
+        <span>
+          <browser-support-icon class="support-available">
+          </browser-support-icon>
+        </span>
+        <span>
+          <browser-support-icon class="support-unavailable">
+          </browser-support-icon>
+        </span>
+      </div>
+    </div>
+    <span
+      aria-hidden="true"
+      class="open-icon"
+    >
+    </span>
+  </summary>
+  <p>
+    This feature is not Baseline because it does not work in some of the most widely-used browsers.
+  </p>
+  <p>
+    <a
+      href="https://github.com/web-platform-dx/web-features/blob/main/features/.yml"
+      target="_top"
+    >
+      Learn more
+    </a>
+  </p>
+</details>
+`;
+/* end snapshot Baseline-status renders limited availability correctly when mobile support is missing */
+

--- a/test/baseline-status.test.js
+++ b/test/baseline-status.test.js
@@ -1,6 +1,6 @@
-import {BaselineStatus} from '../baseline-status';
-import {expect, fixture, assert} from '@open-wc/testing';
-import {html} from 'lit/static-html.js';
+import { BaselineStatus } from '../baseline-status';
+import { expect, fixture, assert } from '@open-wc/testing';
+import { html } from 'lit/static-html.js';
 
 describe('Baseline-status', () => {
 
@@ -116,6 +116,34 @@ describe('Baseline-status', () => {
       }
     }
     const el = await fixture(html`<baseline-status featureId="i-dont-exist"></baseline-status>`);
+    await expect(el).shadowDom.to.equalSnapshot();
+  })
+
+
+  it('renders limited availability correctly when mobile support is missing', async () => {
+    window.fetch = async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: () => ({
+          "name": "paint-order",
+          "baseline": {
+            "status": "limited"
+          },
+          "browser_implementations": {
+            "chrome": { status: "available" },
+            "chrome_android": { status: "available" },
+            "edge": { status: "available" },
+            "firefox": { status: "available" },
+            "firefox_android": { status: "available" },
+            "safari": { status: "available" }
+            // safari_ios unavailable
+          }
+        })
+      }
+    }
+    const el = await fixture(html`<baseline-status featureId="paint-order"></baseline-status>`);
+
     await expect(el).shadowDom.to.equalSnapshot();
   })
 });


### PR DESCRIPTION
Fixes #46 

<img width="863" height="109" alt="image" src="https://github.com/user-attachments/assets/d2032c49-1c4c-47e7-a5a8-bf3815d66584" />

- Shows the "unsupported" icon if either/both of a browser's desktop and mobile browsers are missing support for a feature
- Updates the `summary[aria-label]` attribute
- Adds a regression test