### PR TITLE
Link to dist file instead

### DIFF
--- a/baseline-status.js
+++ b/baseline-status.js
@@ -368,7 +368,7 @@ export class BaselineStatus extends LitElement {
         ${description}
       </p>
       <p>
-        ${baseline === 'no_data' ? '' : html`<a href="https://github.com/web-platform-dx/web-features/blob/main/features/${feature.feature_id}.yml" target="_top">Learn more</a>`}
+        ${baseline === 'no_data' ? '' : html`<a href="https://github.com/web-platform-dx/web-features/blob/main/features/${feature.feature_id}.yml.dist" target="_top">Learn more</a>`}
       </p>
     </details>`;
   }

--- a/baseline-status.js
+++ b/baseline-status.js
@@ -368,7 +368,7 @@ export class BaselineStatus extends LitElement {
         ${description}
       </p>
       <p>
-        ${baseline === 'no_data' ? '' : html`<a href="https://github.com/web-platform-dx/web-features/blob/main/features/${feature.feature_id}.yml.dist" target="_top">Learn more</a>`}
+        ${baseline === 'no_data' ? '' : html`<a href="https://github.com/web-platform-dx/web-features/blob/main/features/${feature.feature_id}.yml.dist" target="_top">Compatibility data</a>`}
       </p>
     </details>`;
   }


### PR DESCRIPTION
Makes progress on #17 

The `dist` file is a much better link IMHO since it gives baseline status, browser support as well as the MDN BCD ids, rather than just the MDN BCD ids.

This is especially useful to identify when mobile versions are missing, or some BCD entries have some support and it's not obvious from looking at them.

For example,

https://github.com/web-platform-dx/web-features/blob/main/features/scroll-buttons.yml.dist
is more useful than:
https://github.com/web-platform-dx/web-features/blob/main/features/scroll-buttons.yml.dist
As can see two features are missing support

https://github.com/web-platform-dx/web-features/blob/main/features/beforeunload.yml.dist
is more useful than:
https://github.com/web-platform-dx/web-features/blob/main/features/beforeunload.yml.dist
As can see iOS dropped support.

The only down sides are:
- To edit it, you need to look at the non-dist file. But to do that you need to do it locally anyway to run `npm run dist` so not sure that's really that much of an issue.
- Missing description, but that should be obvious from the page the widget is linking from. Or, alternatively, if that is a real downside then maybe we should add the description to the widget (but that would mean loading both)? Or add description to the dist file?