### PR TITLE
Avoid fetches for empty feature IDs

### DIFF
--- a/baseline-status.js
+++ b/baseline-status.js
@@ -221,17 +221,24 @@ export class BaselineStatus extends LitElement {
     };
   }
 
-  updated(changedProperties) {
+  willUpdate(changedProperties) {
     changedProperties.forEach((oldValue, propName) => {
       // Reflect feature-id attribute (feature_id prop) to featureId prop.
       if (propName === 'feature_id') {
-        this['featureId'] = this.feature_id
+        this['featureId'] = this.normalizeFeatureId(this.feature_id);
       }
     });
   }
 
+  normalizeFeatureId(featureId) {
+    return typeof featureId === 'string' ? featureId.trim() : featureId;
+  }
+
   fetchData = new Task(this, {
     task: async ([featureId], { signal }) => {
+      if (!featureId) {
+        return undefined;
+      }
       const url = API_ENDPOINT + featureId;
       const response = await fetch(url, { signal, cache: 'force-cache' });
       if (!response.ok) {
@@ -239,7 +246,7 @@ export class BaselineStatus extends LitElement {
       }
       return response.json();
     },
-    args: () => [this.featureId],
+    args: () => [this.normalizeFeatureId(this.featureId)],
   });
 
   checkAvailability(implementations) {

--- a/test/baseline-status.test.js
+++ b/test/baseline-status.test.js
@@ -1,5 +1,5 @@
 import { BaselineStatus } from '../baseline-status';
-import { expect, fixture, assert } from '@open-wc/testing';
+import { expect, fixture, assert, aTimeout, waitUntil } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 
 describe('Baseline-status', () => {
@@ -18,6 +18,89 @@ describe('Baseline-status', () => {
   it('renders with default values', async () => {
     const el = await fixture(html`<baseline-status></baseline-status>`);
     await expect(el).shadowDom.to.equalSnapshot();
+  })
+
+  it('does not fetch without a feature id', async () => {
+    const requests = [];
+    window.fetch = async (url) => {
+      requests.push(url);
+      return {
+        ok: true,
+        status: 200,
+        json: () => ({})
+      }
+    }
+
+    const el = await fixture(html`<baseline-status></baseline-status>`);
+    await el.updateComplete;
+    // Let any async Task run attempt happen before asserting it did not fetch.
+    await aTimeout(0);
+
+    assert.equal(requests.length, 0);
+  })
+
+  it('does not fetch when feature-id is empty', async () => {
+    const requests = [];
+    window.fetch = async (url) => {
+      requests.push(url);
+      return {
+        ok: true,
+        status: 200,
+        json: () => ({})
+      }
+    }
+
+    const el = await fixture(html`<baseline-status feature-id=""></baseline-status>`);
+    await el.updateComplete;
+    // Let any async Task run attempt happen before asserting it did not fetch.
+    await aTimeout(0);
+
+    assert.equal(requests.length, 0);
+  })
+
+  it('fetches when feature-id is dynamically set and updated', async () => {
+    const requests = [];
+    window.fetch = async (url) => {
+      requests.push(url);
+      return {
+        ok: true,
+        status: 200,
+        json: () => ({
+          "name": "Dynamic feature",
+          "baseline": {
+            "status": "widely",
+            "high_date": "2018-01-29",
+            "low_date": "2015-07-29",
+          },
+          "browser_implementations": {}
+        })
+      }
+    }
+
+    const el = await fixture(html`<baseline-status></baseline-status>`);
+    await el.updateComplete;
+    // Let any async Task run attempt happen before asserting it did not fetch.
+    await aTimeout(0);
+
+    assert.equal(requests.length, 0);
+
+    el.setAttribute('feature-id', 'array');
+    await waitUntil(() => requests.length === 1, 'feature-id set should fetch once');
+
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0], 'https://api.webstatus.dev/v1/features/array');
+
+    el.setAttribute('feature-id', 'anchor-positioning');
+    await waitUntil(() => requests.length === 2, 'feature-id update should fetch again');
+
+    assert.equal(requests.length, 2);
+    assert.equal(requests[1], 'https://api.webstatus.dev/v1/features/anchor-positioning');
+
+    el.setAttribute('feature-id', '');
+    // Clearing feature-id should not schedule another request.
+    await aTimeout(0);
+
+    assert.equal(requests.length, 2);
   })
 
   it('renders baseline-low widget for an existing feature', async () => {
@@ -102,7 +185,7 @@ describe('Baseline-status', () => {
         })
       }
     }
-    const el = await fixture(html`<baseline-status featureId="array"></baseline-status>`);
+    const el = await fixture(html`<baseline-status feature-id="array"></baseline-status>`);
     await expect(el).shadowDom.to.equalSnapshot();
   })
 


### PR DESCRIPTION
## Summary

Fixes #80 by preventing `<baseline-status>` from requesting WebStatus API URLs when the feature id is missing, empty, or whitespace-only.

## What changed

- Normalize feature ids with `trim()` so values like `" "` are treated as empty.
- Sync the `feature-id` attribute alias to `featureId` in `willUpdate()` instead of `updated()`.
- Guard the `@lit/task` fetch path so falsy normalized ids return before calling `fetch()`.
- Add regression tests for no feature id, empty `feature-id`, dynamic `feature-id` updates, and clearing `feature-id`.

## Why `willUpdate()`

Lit already handles `attributeChangedCallback()` for reactive properties, so this PR does not override it.

The alias sync belongs in `willUpdate()` because it computes state needed by the upcoming update. This also lets `@lit/task` see the normalized `featureId` before it checks its args and decides whether to run.

The previous `updated()` sync happened after render, and could schedule a second update. Moving the sync earlier keeps the behavior in Lit's normal lifecycle.

## Test notes

The negative fetch tests use `aTimeout(0)` after `updateComplete` to give any async `Task` run attempt a chance to happen before asserting that no request was made.

The dynamic positive cases use `waitUntil()` to wait for the observable fetch count to stabilize rather than relying on a particular browser tick.

## Validation

- `npx eslint baseline-status.js test/baseline-status.test.js`
- `PATH=/Users/schalkneethling/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test`

All 11 browser tests pass.